### PR TITLE
fix(banner): updating slot name to show subheader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,7 +82,7 @@ function App() {
           </div>
           <div className="announcement-banner">
             <tds-banner type="information" icon="info" header="React demo" persistent>
-              <div slot="banner-subheader">
+              <div slot="subheader">
                 This is a demo page in React using{' '}
                 <tds-link style={{ display: 'inline-block' }}>
                   <a href="https://tegel-storybook.netlify.app/?path=/docs/components--banner">

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,7 @@ body,
 
 tds-header {
   position: sticky;
+  top: 68px;
 }
 
 .side-menu-and-main {


### PR DESCRIPTION
Updated Banner subheader slot name to show subheader again and restored top padding on Header to fix blank space above Side Menu on scroll.

Fixes: https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-2142 and https://tegel.atlassian.net/jira/software/projects/DTS/boards/1?selectedIssue=DTS-2145