### PR TITLE
fix(multiselect-table): indeterminate state

### DIFF
--- a/src/components/Table/BatchActionTable.tsx
+++ b/src/components/Table/BatchActionTable.tsx
@@ -20,14 +20,16 @@ const BatchActionTable = () => {
   const [noneSelected, setNoneSelected] = useState(exampleData.every((row) => !row.selected));
   const [data, setData] = useState(exampleData);
 
-  const handleSelectAll = (event: any) => {
+  const handleSelectAll = (event: CustomEvent<{ checked: boolean }>) => {
     const updatedData = data?.map((row) => ({
       ...row,
       selected: event.detail.checked,
     }));
     setData(updatedData);
-    setAllSelected(updatedData.every((row) => row.selected));
-    setNoneSelected(updatedData.every((row) => !row.selected));
+    const allRowsSelected = updatedData.every((row) => row.selected);
+    const noRowsSelected = updatedData.every((row) => !row.selected);
+    setAllSelected(!noRowsSelected && allRowsSelected);
+    setNoneSelected(noRowsSelected);
   };
 
   const handleSelect = (
@@ -45,7 +47,7 @@ const BatchActionTable = () => {
     setData(updatedData);
     const allRowsSelected = updatedData.every((row) => row.selected);
     const noRowsSelected = updatedData.every((row) => !row.selected);
-    setAllSelected(allRowsSelected);
+    setAllSelected(!noRowsSelected && allRowsSelected);
     setNoneSelected(noRowsSelected);
   };
 
@@ -93,7 +95,7 @@ const BatchActionTable = () => {
         </TdsTableToolbar>
         <TdsTableHeader
           onTdsSelectAll={handleSelectAll}
-          selected={allSelected}
+          selected={allSelected && !noneSelected}
           indeterminate={!allSelected && !noneSelected}
         >
           <TdsHeaderCell cellKey="truck" cellValue="Truck type"></TdsHeaderCell>

--- a/src/components/Table/BatchActionTable.tsx
+++ b/src/components/Table/BatchActionTable.tsx
@@ -21,12 +21,13 @@ const BatchActionTable = () => {
   const [data, setData] = useState(exampleData);
 
   const handleSelectAll = (event: any) => {
-    setAllSelected(true);
     const updatedData = data?.map((row) => ({
       ...row,
       selected: event.detail.checked,
     }));
     setData(updatedData);
+    setAllSelected(updatedData.every((row) => row.selected));
+    setNoneSelected(updatedData.every((row) => !row.selected));
   };
 
   const handleSelect = (

--- a/src/components/Table/BatchActionTable.tsx
+++ b/src/components/Table/BatchActionTable.tsx
@@ -43,8 +43,10 @@ const BatchActionTable = () => {
       };
     });
     setData(updatedData);
-    setAllSelected(updatedData.every((row) => row.selected));
-    setNoneSelected(updatedData.every((row) => !row.selected));
+    const allRowsSelected = updatedData.every((row) => row.selected);
+    const noRowsSelected = updatedData.every((row) => !row.selected);
+    setAllSelected(allRowsSelected);
+    setNoneSelected(noRowsSelected);
   };
 
   const handleClick = async () => {

--- a/src/components/Table/BatchActionTable.tsx
+++ b/src/components/Table/BatchActionTable.tsx
@@ -16,7 +16,8 @@ const BatchActionTable = () => {
   const batchActionTable = useRef<HTMLTdsTableElement>(null);
   const modal = useRef<HTMLTdsModalElement>(null);
   const [selectedData, setSelectedData] = useState<any[]>();
-  const [allSelected, setAllSelected] = useState(exampleData.every((row) => row.selected));
+  const [allSelected, setAllSelected] = useState(!exampleData.some((row) => row.selected));
+  const [noneSelected, setNoneSelected] = useState(exampleData.every((row) => !row.selected));
   const [data, setData] = useState(exampleData);
 
   const handleSelectAll = (event: any) => {
@@ -42,6 +43,7 @@ const BatchActionTable = () => {
     });
     setData(updatedData);
     setAllSelected(updatedData.every((row) => row.selected));
+    setNoneSelected(updatedData.every((row) => !row.selected));
   };
 
   const handleClick = async () => {
@@ -86,7 +88,11 @@ const BatchActionTable = () => {
             text="Download"
           ></TdsButton>
         </TdsTableToolbar>
-        <TdsTableHeader onTdsSelectAll={handleSelectAll} allSelected={allSelected}>
+        <TdsTableHeader
+          onTdsSelectAll={handleSelectAll}
+          selected={allSelected}
+          indeterminate={!allSelected && !noneSelected}
+        >
           <TdsHeaderCell cellKey="truck" cellValue="Truck type"></TdsHeaderCell>
           <TdsHeaderCell cellKey="driver" cellValue="Driver name"></TdsHeaderCell>
           <TdsHeaderCell cellKey="country" cellValue="Country"></TdsHeaderCell>


### PR DESCRIPTION
Fix for the issue: https://github.com/scania-digital-design-system/tegel-react-demo/issues/173

How to test: 

1. Open preview link
2. Go to table page
3. Play with selections on single and parent checkbox under "Batch actions"
4. When all single are selected parent checkbox goes to selected state too
5. When one single selection is missing, parent selection goes to indeterminate state
6. When none of single rows is selected, parent selection is empty too
